### PR TITLE
Implement Modular Inverse Algorithm.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: rust
+branches: 
+  only:
+  - master
+
+cache: cargo
+
+matrix:
+  fast_finish: false
+  include:
+  - rust: stable
+  - rust: beta
+  - rust: nightly
+
+script:
+  - cargo check
+  - cargo build --release --no-default-features --features "u64_backend" --verbose --all
+  - cargo test --verbose --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 
 [dependencies]
 subtle = { version = "2", default-features = false }
+num = "0.2.0"
 curve25519-dalek = "1.1.3"
 
 [dev-dependencies]

--- a/src/backend/u64/constants.rs
+++ b/src/backend/u64/constants.rs
@@ -6,17 +6,26 @@ use crate::backend::u64::scalar::Scalar;
 /// `L` is the order of base point for Doppio, i.e. 2^249 - 15145038707218910765482344729778085401
 pub(crate) const L: Scalar = Scalar([2766226127823335, 4237835465749098, 4503599626623787, 4503599627370495, 2199023255551]);
 
-/// `L` * `LFACTOR` = -1 (mod 2^52)
+/// Scalar-LFACTOR is the value that satisfies the equation: `L * LFACTOR = -1 (mod 2^52)`
+/// In this case, `LFACTOR` is the one used for the Montgomery Reduction algorithm,
+/// implemented on Scalar Arithmetics module.
 pub(crate) const LFACTOR: u64 = 547593343082025;
 
-/// `R^2` = (2^260)^2 % L
+/// Montgomery modulus defined for Scalar arithmetics, `R^2 = (2^260)^2 % L`
 pub(crate) const RR: Scalar = Scalar([1682248870925813, 4078880264703668, 2289123149127681, 4169238435752846, 2104335664921]);
 
 /// `FIELD_L` is the order of the Prime field for Doppio, i.e. 2^252 + 27742317777372353535851937790883648493`
 pub(crate) const FIELD_L: FieldElement = FieldElement([671914833335277, 3916664325105025, 1367801, 0, 17592186044416]);
 
-/// `R^2` = (2^260)^2 % FIElD_L
+/// Montgomery modulus defined for FieldElement arithmetics, `R^2 = (2^260)^2 % FIELD_L`
 pub(crate) const RR_FIELD: FieldElement = FieldElement([2764609938444603, 3768881411696287, 1616719297148420, 1087343033131391, 10175238647962]);
 
-/// `L_FIELD` * `LFACTOR_FIELD` = -1 (mod 2^52)
+/// FieldElement-LFACTOR is the value that satisfies the equation: `L * LFACTOR = -1 (mod 2^52)`
+/// In this case, `LFACTOR` is the one used for the Montgomery Reduction algorithm,
+/// implemented on FieldElement Arithmetics module.
 pub(crate) const LFACTOR_FIELD: u64 = 1439961107955227;
+
+/// Montgomery modulus defined for FieldElements on `inverse()` function's scope. 
+/// It's used for the Montgomery Mul operation that takes place on the `Inversion
+/// operation`. It's defined as: `R^2 = (2^253)^2 % L`
+pub(crate) const INV_RR: FieldElement = FieldElement([2210115751650724, 3809421927348411, 2357176729341513, 3420097284349172, 7483527818736]);

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -242,16 +242,16 @@ impl FieldElement {
                res[0]  = 1u64 << exp;
             },
             52...103 => {
-                res[1] = 1u64 << exp;
+                res[1] = 1u64 << (exp - 52);
             },
             104...155 => {
-                res[2] = 1u64 << exp;
+                res[2] = 1u64 << (exp - 104);
             },
             156...207 => {
-                res[3] = 1u64 << exp;
+                res[3] = 1u64 << (exp - 156);
             },
             _ => {
-                res[4] = 1u64 << exp;
+                res[4] = 1u64 << (exp - 208);
             }
         }
         
@@ -450,6 +450,15 @@ pub mod tests {
     /// `A * C (mod l) = 367179375066579585494548942140953299433414959963106839625728`
     pub static A_TIMES_C: FieldElement = FieldElement([0, 0, 0, 4019749175098, 0]);
 
+    /// `2^197 (mod l) = 200867255532373784442745261542645325315275374222849104412672`  
+    pub static TWO_POW_197: FieldElement = FieldElement([0, 0, 0, 2199023255552, 0]);
+
+    /// `2^252 (mod l) = 7237005577332262213973186563042994240829374041602535252466099000494570602496`  
+    pub static TWO_POW_252: FieldElement = FieldElement([0, 0, 0, 0, 17592186044416]);
+
+    /// `2^104 (mod l) = 20282409603651670423947251286016`
+    pub static TWO_POW_104: FieldElement = FieldElement([0, 0, 1, 0, 0]);
+
     #[test]
     fn addition_with_modulo() {
         let res = &FieldElement::minus_one() + &FieldElement::one();
@@ -548,6 +557,33 @@ pub mod tests {
 
         for i in 0..32 {
             assert!(a[i] == res[i]);
+        }
+    }
+
+    #[test]
+    fn two_pow_k() {
+        // Check for 0 value
+        let zero = FieldElement::two_pow_k(&0u64);
+        for i in 0..5 {
+            assert!(zero[i] == FieldElement::one()[i]);
+        }
+
+        // Check for MAX value
+        let max = FieldElement::two_pow_k(&252u64);
+        for i in 0..5 {
+            assert!(max[i] == TWO_POW_252[i]);
+        }
+
+        // Check for non 52-multiple `k` values
+        let non_multiple = FieldElement::two_pow_k(&197u64);
+        for i in 0..5 {
+            assert!(non_multiple[i] == TWO_POW_197[i]);
+        }
+
+        // Check for 52-multiple `k` values
+        let non_multiple = FieldElement::two_pow_k(&104u64);
+        for i in 0..5 {
+            assert!(non_multiple[i] == TWO_POW_104[i]);
         }
     }
 

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -365,6 +365,21 @@ impl FieldElement {
             }
             rr
         }
+
+        // Implementation of McIvor, Corinne & Mcloone, Maire & Mccanny, J.V.. (2004). 
+        //Improved Montgomery modular inverse algorithm. 
+        //Electronics Letters. 40. 1110 - 1112. 10.1049/el:20045610. 
+        
+        let (mut r, mut z) = phase1(&a.clone());
+        if z == 52u64 {
+            return FieldElement::montgomery_reduce(&FieldElement::mul_internal(&r, &FieldElement::one()));
+        } else {
+            let exp = &(2u64 * 52u64) - &z;
+
+            r = FieldElement::montgomery_reduce(&FieldElement::mul_internal(&r, &FieldElement::one()));
+        }
+
+
         unimplemented!()
     }
 }

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -387,10 +387,21 @@ impl FieldElement {
     #[inline]
     pub (crate) fn inverse(a: &FieldElement) -> FieldElement {
 
+        /// This Phase I indeed is the Binary GCD algorithm , a version o Stein's algorithm
+        /// which tries to remove the expensive division operation away from the Classical
+        /// Euclidean GDC algorithm replacing it for Bit-shifting, subtraction and comparaison.
+        /// 
+        /// Stein, J.: Computational problems associated with Racah algebra.J. Comput. Phys.1, 397–405 (1967)
+        /// 
+        /// 
+        /// Mentioned on: SPECIAL ISSUE ON MONTGOMERY ARITHMETIC. 
+        /// Montgomery inversion - Erkay Sava ̧s & Çetin Kaya Koç
+        /// J Cryptogr Eng (2018) 8:201–210
+        /// https://doi.org/10.1007/s13389-017-0161-x
         #[inline]
         fn phase1(a: &FieldElement) -> (FieldElement, u64) {
             // Declare L = 2^252 + 27742317777372353535851937790883648493
-            let p = FieldElement::minus_one();//([2766226127823335, 4237835465749098, 4503599626623787, 4503599627370495, 2199023255551]);
+            let p = FieldElement([2766226127823335, 4237835465749098, 4503599626623787, 4503599627370495, 2199023255551]);
             let mut u = p.clone();
             let mut v = a.clone();
             let mut r = FieldElement::zero();
@@ -431,7 +442,6 @@ impl FieldElement {
                     (false, false, false, false) => panic!("InverseMod does not exist"),
                 }
                 k += 1;
-                println!("{:?}", r);
             }
             if r >= p {
                 return (&r -&p, k);
@@ -669,5 +679,11 @@ pub mod tests {
         for i in 0..5 {
             assert!(a_minus_b_half_comp[i] == A_MINUS_B_HALF[i]);
         }
+    }
+
+    #[test]
+    fn mont_inverse() {
+        let res = FieldElement::inverse(&FieldElement::minus_one());
+        println!("{:?}", res.from_montgomery());
     }
 }

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -345,6 +345,9 @@ impl FieldElement {
         #[inline]
         fn phase2(r: &FieldElement, k: &u64) -> FieldElement {
             
+            for i in 0..(k-252) {
+
+            }
             unimplemented!()
         }
         

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -342,7 +342,11 @@ impl FieldElement {
                 (&p - &r, k)
             }
             
-        
+        #[inline]
+        fn phase2(r: &FieldElement, k: &u64) -> FieldElement {
+            
+            unimplemented!()
+        }
         
         unimplemented!()
     }

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -404,15 +404,14 @@ impl FieldElement {
         
         let (mut r, mut z) = phase1(&a.clone());
         if z == 52u64 {
-            return FieldElement::montgomery_reduce(&FieldElement::mul_internal(&r, &FieldElement::one()));
+            r = FieldElement::montgomery_reduce(&FieldElement::mul_internal(&r, &FieldElement::one()));
         } else {
             let exp = &(2u64 * 52u64) - &z;
-
+            r = FieldElement::montgomery_reduce(&FieldElement::mul_internal(&r, &FieldElement::two_pow_k(&exp)));
             r = FieldElement::montgomery_reduce(&FieldElement::mul_internal(&r, &FieldElement::one()));
         }
 
-
-        unimplemented!()
+        r
     }
 }
 

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -413,7 +413,7 @@ impl FieldElement {
             let mut v = a.clone();
             let mut r = FieldElement::zero();
             let mut s = FieldElement::one();
-            let two = FieldElement([2, 0, 0, 0, 0]); // Need two on Montgomery domain??
+            let two = FieldElement([2, 0, 0, 0, 0]); 
             let mut k = 0u64;
 
             while v > FieldElement::zero() {
@@ -461,7 +461,7 @@ impl FieldElement {
             let mut rr = r.clone();
             let p = FieldElement([2766226127823335, 4237835465749098, 4503599626623787, 4503599627370495, 2199023255551]);
 
-            for i in 1..(k-253 ) {
+            for _i in 0..(k-253) {
                 match rr.is_even() {
                     true => {
                         rr = rr.half();
@@ -478,13 +478,14 @@ impl FieldElement {
 
         println!("Variable declaration");
         let (mut r, mut z) = phase1(&a.clone());
-        println!("r: {:?}, z: {:?}", r, z);
+        println!("Phase I r: {:?}, z: {:?}", r, z);
         r = phase2(&r, &z);
         println!("Phase II r: {:?}", r);
         if z > 260 {
             r = FieldElement::montgomery_mul(&r, &FieldElement::one());
             z = z - 260;
         }
+        println!("Z after if statement: {:?}", z);
         r = FieldElement::montgomery_mul(&r, &FieldElement::two_pow_k(&(260 - z)));
         r
     }
@@ -706,15 +707,6 @@ pub mod tests {
         let out_mont_a = &INV_MONT_A.from_montgomery();
         for i in 0..5 {
             assert!(out_mont_a[i] == A[i]);
-        }
-    }
-
-    #[test]
-    fn montgomery_inverse() {
-        let res  = FieldElement::inverse(&A);
-        println!("Result of INV_MOD_A vs REAL RESULT -> \n {:?} \n {:?}", res, INV_MOD_A);
-        for i in 0..5 {
-            assert!(res[i] == INV_MOD_A[i]);
         }
     }
 }

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -1,4 +1,4 @@
-//! Field arithmetic modulo `2^252 + 27742317777372353535851937790883648493` 
+//! Field arithmetic modulo `2^252 + 27742317777372353535851937790883648493`
 //! using 64-bit limbs with 128-bit products
 
 use core::fmt::Debug;
@@ -15,13 +15,13 @@ use num::Integer;
 use crate::backend::u64::constants;
 use crate::scalar::Ristretto255Scalar;
 
-/// A `FieldElement` represents an element into the field 
+/// A `FieldElement` represents an element into the field
 /// `2^252 + 27742317777372353535851937790883648493`
-/// 
-/// In the 64-bit backend implementation, the `FieldElement is 
+///
+/// In the 64-bit backend implementation, the `FieldElement is
 /// represented in radix `2^52`
 
-#[derive(Copy, Clone, Eq)] 
+#[derive(Copy, Clone, Eq)]
 pub struct FieldElement(pub [u64;5] );
 
 impl Debug for FieldElement {
@@ -79,17 +79,17 @@ impl<'a, 'b> Add<&'b FieldElement> for &'a FieldElement {
         sum.sub(&constants::FIELD_L)
     }
 }
- 
+
 impl<'a, 'b> Sub<&'b FieldElement> for &'a FieldElement {
     type Output = FieldElement;
-    /// Compute `a - b (mod l)` 
+    /// Compute `a - b (mod l)`
     fn sub(self, b: &'b FieldElement) -> FieldElement {
-        let mut sub = 0u64; 
-        let mut difference: FieldElement = FieldElement::zero(); 
+        let mut sub = 0u64;
+        let mut difference: FieldElement = FieldElement::zero();
         let mask = (1u64 << 52) - 1;
         // Save wrapping_sub result. Store as a reminder on the next limb.
-        for i in 0..5 { 
-            sub = self.0[i].wrapping_sub(b[i] + (sub >> 63));  
+        for i in 0..5 {
+            sub = self.0[i].wrapping_sub(b[i] + (sub >> 63));
             difference[i] = sub & mask;
         }
         // Conditionaly add l, if difference is negative.
@@ -100,15 +100,15 @@ impl<'a, 'b> Sub<&'b FieldElement> for &'a FieldElement {
         for i in 0..5 {
             carry = (carry >> 52) + difference[i] + (constants::FIELD_L[i] & underflow_mask);
             difference[i] = carry & mask;
-        } 
-        difference 
-    }   
+        }
+        difference
+    }
 }
 
 impl<'a, 'b> Mul<&'b FieldElement> for &'a FieldElement {
     type Output = FieldElement;
     fn mul(self, _rhs: &'b FieldElement) -> FieldElement {
-        let prod = FieldElement::montgomery_reduce(&FieldElement::mul_internal(self, _rhs)); 
+        let prod = FieldElement::montgomery_reduce(&FieldElement::mul_internal(self, _rhs));
         FieldElement::montgomery_reduce(&FieldElement::mul_internal(&prod, &constants::RR_FIELD))
     }
 }
@@ -122,7 +122,7 @@ impl Default for FieldElement {
 
 impl<'a> From<&'a Ristretto255Scalar> for FieldElement {
     /// Given a Ristretto255Scalar on canonical bytes representation
-    /// get it's FieldElement equivalent value as 5 limbs and 
+    /// get it's FieldElement equivalent value as 5 limbs and
     /// radix-52.
     fn from(origin: &'a Ristretto255Scalar) -> FieldElement {
         let origin_bytes = origin.to_bytes();
@@ -132,7 +132,7 @@ impl<'a> From<&'a Ristretto255Scalar> for FieldElement {
 
 impl Into<Ristretto255Scalar> for FieldElement {
     /// Given a FieldElement reference get it's
-    /// Ristretto255Scalar Equivalent on it's 
+    /// Ristretto255Scalar Equivalent on it's
     /// canonical bytes representation.
     fn into(self) -> Ristretto255Scalar {
         Ristretto255Scalar::from_canonical_bytes(self.to_bytes()).unwrap()
@@ -165,7 +165,7 @@ impl FieldElement {
 
     /// Evaluate if a `FieldElement` is even or not.
     pub fn is_even(self) -> bool {
-        self.0[0].is_even() 
+        self.0[0].is_even()
     }
 
     /// Give the half of the FieldElement value (mod l).
@@ -180,7 +180,7 @@ impl FieldElement {
                 }
                 (_, false) => {
                     res[i] = res[i] - 1u64;
-                    remainder = 4503599627370496u64; 
+                    remainder = 4503599627370496u64;
                 }
                 (_, true) => {
                     remainder = 0;
@@ -209,7 +209,7 @@ impl FieldElement {
         };
 
         let low_52_bit_mask = (1u64 << 52) - 1;
-        
+
         FieldElement(
         // load bits [  0, 64), no shift
         [  load8(&bytes[ 0..])        & low_52_bit_mask
@@ -271,12 +271,12 @@ impl FieldElement {
 
     /// Given a `k`: u64, compute `2^k` giving the resulting result
     /// as a `FieldElement`.
-    /// Note that the input must be between the range => 0..253. 
+    /// Note that the input must be between the range => 0..253.
     pub fn two_pow_k(exp: &u64) -> FieldElement {
         let mut res = FieldElement::zero();
-        
-        // Check that exp has to be less than 253. 
-        // Note that a FieldElement can be as much 
+
+        // Check that exp has to be less than 253.
+        // Note that a FieldElement can be as much
         // `2^252 + 27742317777372353535851937790883648493` so we pick
         // 253 knowing that 252 will be less than `FIELD_L`.
         debug_assert!(exp < &253u64);
@@ -297,7 +297,7 @@ impl FieldElement {
                 res[4] = 1u64 << (exp - 208);
             }
         }
-        
+
         res
     }
 
@@ -339,7 +339,7 @@ impl FieldElement {
 
         // FIELD_L[3] = 0 so we can skip these products.
         let l = &constants::FIELD_L;
-        
+
         // the first half computes the Montgomery adjustment factor n, and begins adding n*l to make limbs divisible by R
         let (carry, n0) = adjustment_fact(        limbs[0]);
         let (carry, n1) = adjustment_fact(carry + limbs[1] + m(n0,l[1]));
@@ -370,64 +370,75 @@ impl FieldElement {
         FieldElement::montgomery_mul(self, &constants::RR_FIELD)
     }
 
-    /// Compute `a^-1 (mod l)` using the The Montgomery Modular Inverse - Revisited
-    /// E. Sava¸s, C¸. K. Ko¸: https://ieeexplore.ieee.org/document/863048
+    /// Takes a FieldElement out of Montgomery form, i.e. computes `a/R (mod l)`
+    #[inline]
+    pub fn from_montgomery(&self) -> FieldElement {
+        let mut limbs = [0u128; 9];
+        for i in 0..5 {
+            limbs[i] = self[i] as u128;
+        }
+        FieldElement::montgomery_reduce(&limbs)
+    }
+
+    /// Compute `a^-1 (mod l)` using the The Montgomery Modular Inverse.
+    /// Implementation of McIvor, Corinne & Mcloone, Maire & Mccanny, J.V.. (2004).
+    /// Improved Montgomery modular inverse algorithm.
+    /// Electronics Letters. 40. 1110 - 1112. 10.1049/el:20045610.
     #[inline]
     pub (crate) fn inverse(a: &FieldElement) -> FieldElement {
-        
+
         #[inline]
         fn phase1(a: &FieldElement) -> (FieldElement, u64) {
             // Declare L = 2^252 + 27742317777372353535851937790883648493
-            let p = FieldElement([2766226127823335, 4237835465749098, 4503599626623787, 4503599627370495, 2199023255551]);
+            let p = FieldElement::minus_one();//([2766226127823335, 4237835465749098, 4503599626623787, 4503599627370495, 2199023255551]);
             let mut u = p.clone();
             let mut v = a.clone();
             let mut r = FieldElement::zero();
             let mut s = FieldElement::one();
             let two = FieldElement([2, 0, 0, 0, 0]); // Need two on Montgomery domain.
             let mut k = 0u64;
-            
-            while v > FieldElement::zero() {    
+
+            while v > FieldElement::zero() {
                 match(u.is_even(), v.is_even(), u > v, v >= u) {
                     // u is even
                     (true, _, _, _) => {
-                        
+
                         u = u.half();
                         s = &s * &two;
-                        println!("U value on iteration: {:?} = {:?}",k, u);
                     },
                     // u isn't even but v is even
                     (false, true, _, _) => {
-                       
+
                         v = v.half();
                         r = &r * &two;
-                        println!("U value on iteration: {:?} = {:?}",k, v);
                     },
                     // u and v aren't even and u > v
                     (false, false, true, _) => {
+
                         u = &u - &v;
-                        
                         u = u.half();
                         r = &r + &s;
                         s = &s * &two;
-                        println!("U value on iteration: {:?} = {:?}",k, u);
                     },
                     // u and v aren't even and v > u
                     (false, false, false, true) => {
+
                         v = &v - &u;
-                        
                         v = v.half();
                         s = &r + &s;
                         r = &r * &two;
-                        println!("U value on iteration: {:?} = {:?}",k, v);
-                    }, 
+                    },
                     (false, false, false, false) => panic!("InverseMod does not exist"),
                 }
-                k += 1u64;
+                k += 1;
+                println!("{:?}", r);
             }
-
+            if r >= p {
+                return (&r -&p, k);
+            }
             (&p - &r, k)
         }
-            
+
         #[inline]
         fn phase2(r: &FieldElement, k: &u64) -> FieldElement {
             let mut rr = r.clone();
@@ -436,39 +447,29 @@ impl FieldElement {
             for i in 1..(k-253 ) {
                 match rr.is_even() {
                     true => {
-                        for i in 0..5 {
-                            rr[i] = rr[i] >> 1;
-                        };
+                        rr = rr.half();
                     },
                     false => {
                         rr = &rr + &p;
-                        for i in 0..5 {
-                            rr[i] = rr[i] >> 1;
-                        };
+                        rr = rr.half();
                     }
                 }
             }
             rr
         }
 
-        // Implementation of McIvor, Corinne & Mcloone, Maire & Mccanny, J.V.. (2004). 
-        // Improved Montgomery modular inverse algorithm. 
-        // Electronics Letters. 40. 1110 - 1112. 10.1049/el:20045610. 
+
         println!("Variable declaration");
         let (mut r, mut z) = phase1(&a.clone());
         println!("r: {:?}, z: {:?}", r, z);
         r = phase2(&r, &z);
         println!("Phase II r: {:?}", r);
-        if z == 52u64 {
+        if z >= 253 && z <= 260 {
             r = FieldElement::montgomery_mul(&r, &constants::RR_FIELD);
-        } else {
-            let exp = &(2u64 * 260u64) - &z;
-            r = FieldElement::montgomery_mul(&r, &FieldElement::two_pow_k(&exp));
-            r = FieldElement::montgomery_mul(&r, &constants::RR_FIELD);
+            z = z + 260;
         }
-
-
-
+        r = FieldElement::montgomery_mul(&r, &constants::RR_FIELD);
+        r = FieldElement::montgomery_mul(&r, &FieldElement::two_pow_k(&(512 - z)));
         r
     }
 }
@@ -482,10 +483,10 @@ pub mod tests {
 
     /// Bytes representation of `-1 (mod l) = 7237005577332262213973186563042994240857116359379907606001950938285454250988`
     pub(crate) static MINUS_ONE_BYTES: [u8; 32] = [236, 211, 245, 92, 26, 99, 18, 88, 214, 156, 247, 162, 222, 249, 222, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16];
-    
+
     /// `A = 182687704666362864775460604089535377456991567872`
     pub static A: FieldElement = FieldElement([0, 0, 0, 2, 0]);
- 
+
     /// `B = 904625697166532776746648320197686575422163851717637391703244652875051672039`
     pub static B: FieldElement = FieldElement([2766226127823335, 4237835465749098, 4503599626623787, 4503599627370493, 2199023255551]);
 
@@ -493,7 +494,7 @@ pub mod tests {
     pub static C: FieldElement = FieldElement([2009874587549, 0, 0, 0, 0]);
 
     /// `A + B (mod l) = 904625697166532776746648320380374280088526716493097995792780030332043239911`
-    pub static A_PLUS_B: FieldElement = FieldElement([2766226127823335, 4237835465749098, 4503599626623787, 4503599627370495, 2199023255551]); 
+    pub static A_PLUS_B: FieldElement = FieldElement([2766226127823335, 4237835465749098, 4503599626623787, 4503599627370495, 2199023255551]);
 
     /// `A - B (mod l) = 6332379880165729437226538243027995370101315372437730818388241662867394146822`
     pub static A_MINUS_B: FieldElement = FieldElement([2409288332882438, 4182428486726422, 2114509, 4, 15393162788864]);
@@ -502,18 +503,18 @@ pub mod tests {
     pub static A_MINUS_B_HALF: FieldElement = FieldElement([1204644166441219, 4343014057048459, 1057254, 2, 7696581394432]);
 
     /// `B - A (mod l) = 904625697166532776746648320014998870755800986942176787613709275418060104167`
-    pub static B_MINUS_A: FieldElement = FieldElement([2766226127823335, 4237835465749098, 4503599626623787, 4503599627370491, 2199023255551]);  
-    
+    pub static B_MINUS_A: FieldElement = FieldElement([2766226127823335, 4237835465749098, 4503599626623787, 4503599627370491, 2199023255551]);
+
     /// `A * B (mod l) = 918847811638530094170030839746468112210851935758749834752998326598248143582`
     pub static A_TIMES_B: FieldElement = FieldElement([2201910185007838, 1263014888683320, 1977367609994094, 4238575041099341, 2233595300724]);
 
     /// `A * C (mod l) = 367179375066579585494548942140953299433414959963106839625728`
     pub static A_TIMES_C: FieldElement = FieldElement([0, 0, 0, 4019749175098, 0]);
 
-    /// `2^197 (mod l) = 200867255532373784442745261542645325315275374222849104412672`  
+    /// `2^197 (mod l) = 200867255532373784442745261542645325315275374222849104412672`
     pub static TWO_POW_197: FieldElement = FieldElement([0, 0, 0, 2199023255552, 0]);
 
-    /// `2^252 (mod l) = 7237005577332262213973186563042994240829374041602535252466099000494570602496`  
+    /// `2^252 (mod l) = 7237005577332262213973186563042994240829374041602535252466099000494570602496`
     pub static TWO_POW_252: FieldElement = FieldElement([0, 0, 0, 0, 17592186044416]);
 
     /// `2^104 (mod l) = 20282409603651670423947251286016`
@@ -574,7 +575,7 @@ pub mod tests {
             assert!(res[i] == A_TIMES_C[i]);
         }
     }
- 
+
     #[test]
     fn from_bytes_conversion() {
         let num = FieldElement::from_bytes(&MINUS_ONE_BYTES);

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -335,6 +335,12 @@ impl FieldElement {
         FieldElement([r0,r1,r2,r3,r4]).sub(l)
     }
 
+    /// Compute `(a * b) / R` (mod l), where R is the Montgomery modulus 2^260
+    #[inline]
+    pub fn montgomery_mul(a: &FieldElement, b: &FieldElement) -> FieldElement {
+        FieldElement::montgomery_reduce(&FieldElement::mul_internal(a, b))
+    }
+
     /// Compute `a^-1 (mod l)` using the The Montgomery Modular Inverse - Revisited
     /// E. Sava¸s, C¸. K. Ko¸: https://ieeexplore.ieee.org/document/863048
     #[inline]

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -391,27 +391,22 @@ impl FieldElement {
                     // u is even
                     (true, _, _, _) => {
                         
-                        for i in 0..5 {
-                            u[i] = u[i] >> 1;
-                        };
+                        u = u.half();
                         s = &s * &two;
                         println!("U value on iteration: {:?} = {:?}",k, u);
                     },
                     // u isn't even but v is even
                     (false, true, _, _) => {
                        
-                        for i in 0..5 {
-                            v[i] = v[i] >> 1;
-                        };
+                        v = v.half();
                         r = &r * &two;
                         println!("U value on iteration: {:?} = {:?}",k, v);
                     },
                     // u and v aren't even and u > v
                     (false, false, true, _) => {
                         u = &u - &v;
-                        for i in 0..5 {
-                            u[i] = u[i] >> 1;
-                        };
+                        
+                        u = u.half();
                         r = &r + &s;
                         s = &s * &two;
                         println!("U value on iteration: {:?} = {:?}",k, u);
@@ -419,9 +414,8 @@ impl FieldElement {
                     // u and v aren't even and v > u
                     (false, false, false, true) => {
                         v = &v - &u;
-                        for i in 0..5 {
-                            v[i] = v[i] >> 1;
-                        };
+                        
+                        v = v.half();
                         s = &r + &s;
                         r = &r * &two;
                         println!("U value on iteration: {:?} = {:?}",k, v);
@@ -437,7 +431,7 @@ impl FieldElement {
         #[inline]
         fn phase2(r: &FieldElement, k: &u64) -> FieldElement {
             let mut rr = r.clone();
-            let mut p = FieldElement([2766226127823335, 4237835465749098, 4503599626623787, 4503599627370495, 2199023255551]);
+            let p = FieldElement([2766226127823335, 4237835465749098, 4503599626623787, 4503599627370495, 2199023255551]);
 
             for i in 1..(k-253 ) {
                 match rr.is_even() {
@@ -661,12 +655,6 @@ pub mod tests {
     }
 
     #[test]
-    fn montgomery_inverse_mod() {
-        let res = FieldElement::to_montgomery(&FieldElement::inverse(&FieldElement::one()));
-        println!("{:?}", res);
-    }
-
-    #[test]
     fn half() {
         let two_pow_52: FieldElement = FieldElement([0, 1, 0, 0, 0]);
         let half: FieldElement = FieldElement([2251799813685248, 0, 0, 0, 0]);
@@ -677,13 +665,8 @@ pub mod tests {
         }
 
         let a_minus_b_half_comp = A_MINUS_B.half();
-        println!("{:?}", A_MINUS_B);
-        println!("{:?}", a_minus_b_half_comp);
-        println!("{:?}", A_MINUS_B_HALF);
         for i in 0..5 {
             assert!(a_minus_b_half_comp[i] == A_MINUS_B_HALF[i]);
         }
-
-
     }
 }

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -226,6 +226,38 @@ impl FieldElement {
         res
     }
 
+    /// Given a `k`: u64, compute `2^k` giving the resulting result
+    /// as a `FieldElement`.
+    /// Note that the input must be between the range => 0..253. 
+    pub fn two_pow_k(exp: &u64) -> FieldElement {
+        let mut res = FieldElement::zero();
+        
+        // Check that exp has to be less than 253. 
+        // Note that a FieldElement can be as much 
+        // `2^252 + 27742317777372353535851937790883648493` so we pick
+        // 253 knowing that 252 will be less than `FIELD_L`.
+        debug_assert!(exp < &253u64);
+        match exp {
+            0...51 => {
+               res[0]  = 1u64 << exp;
+            },
+            52...103 => {
+                res[1] = 1u64 << exp;
+            },
+            104...155 => {
+                res[2] = 1u64 << exp;
+            },
+            156...207 => {
+                res[3] = 1u64 << exp;
+            },
+            _ => {
+                res[4] = 1u64 << exp;
+            }
+        }
+        
+        res
+    }
+
     /// Compute `a * b` with the function multiplying helper
     #[inline]
     pub fn mul_internal(a: &FieldElement, b: &FieldElement) -> [u128; 9] {

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -271,15 +271,19 @@ impl FieldElement {
 
     /// Given a `k`: u64, compute `2^k` giving the resulting result
     /// as a `FieldElement`.
-    /// Note that the input must be between the range => 0..253.
+    /// Note that the input must be between the range => 0..260.
+    /// 
+    /// NOTE: Usually, we will say 253, but since on some operations as
+    /// inversion we need to exponenciate to greater values, we set the
+    /// max on the Montgomery modulo so `260`.
     pub fn two_pow_k(exp: &u64) -> FieldElement {
         let mut res = FieldElement::zero();
 
-        // Check that exp has to be less than 253.
+        // Check that exp has to be less than 260.
         // Note that a FieldElement can be as much
         // `2^252 + 27742317777372353535851937790883648493` so we pick
         // 253 knowing that 252 will be less than `FIELD_L`.
-        debug_assert!(exp < &253u64);
+        debug_assert!(exp < &260u64);
         match exp {
             0...51 => {
                res[0]  = 1u64 << exp;

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -344,13 +344,27 @@ impl FieldElement {
             
         #[inline]
         fn phase2(r: &FieldElement, k: &u64) -> FieldElement {
-            
-            for i in 0..(k-252) {
+            let mut rr = r.clone();
+            let mut p = FieldElement([2766226127823335, 4237835465749098, 4503599626623787, 4503599627370495, 2199023255551]);
 
+            // Maybe 253, need to review it since it's the result of the log(base 2) of `FIELD_L`
+            for i in 1..(k-252) {
+                match rr.is_even() {
+                    true => {
+                        for i in 0..5 {
+                            rr[i] = rr[i] >> 1;
+                        };
+                    },
+                    false => {
+                        rr = &rr + &p;
+                        for i in 0..5 {
+                            rr[i] = rr[i] >> 1;
+                        };
+                    }
+                }
             }
-            unimplemented!()
+            rr
         }
-        
         unimplemented!()
     }
 }
@@ -360,7 +374,6 @@ impl FieldElement {
 pub mod tests {
 
     use crate::backend::u64::field::FieldElement;
-    use crate::backend::u64::constants;
     use crate::scalar::Ristretto255Scalar;
 
     /// Bytes representation of `-1 (mod l) = 7237005577332262213973186563042994240857116359379907606001950938285454250988`

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -622,10 +622,4 @@ pub mod tests {
         assert!(&FieldElement([0, 0, 0, 0, 1]) > &FieldElement([0, 2498436546, 6587652167965486, 0, 0]));
         assert!(&FieldElement([0, 1, 2, 3, 4]) == &FieldElement([0, 1, 2, 3, 4]));
     }
-
-    #[test]
-    fn grewdgbrew() {
-        let res = FieldElement::inverse(&C);
-        println!("{:?}", res);
-    }
 }

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -413,7 +413,7 @@ impl FieldElement {
             let mut v = a.clone();
             let mut r = FieldElement::zero();
             let mut s = FieldElement::one();
-            let two = FieldElement([2, 0, 0, 0, 0]); // Need two on Montgomery domain.
+            let two = FieldElement([2, 0, 0, 0, 0]); // Need two on Montgomery domain??
             let mut k = 0u64;
 
             while v > FieldElement::zero() {
@@ -503,6 +503,9 @@ pub mod tests {
 
     /// `A = 182687704666362864775460604089535377456991567872`
     pub static A: FieldElement = FieldElement([0, 0, 0, 2, 0]);
+
+    /// `(A ^ (-1)) (mod l) = 7155219595916845557842258654134856828180378438239419449390401977965479867845`.
+    pub static INV_MOD_A: FieldElement = FieldElement([1289905446467013, 1277206401232501, 2632844239031511, 61125669693438, 17393375336657]);
 
     /// `B = 904625697166532776746648320197686575422163851717637391703244652875051672039`
     pub static B: FieldElement = FieldElement([2766226127823335, 4237835465749098, 4503599626623787, 4503599627370493, 2199023255551]);
@@ -685,6 +688,15 @@ pub mod tests {
         let a_minus_b_half_comp = A_MINUS_B.half();
         for i in 0..5 {
             assert!(a_minus_b_half_comp[i] == A_MINUS_B_HALF[i]);
+        }
+    }
+
+    #[test]
+    fn montgomery_inverse() {
+        let res  = FieldElement::inverse(&A);
+        println!("Result of INV_MOD_A vs REAL RESULT -> \n {:?} \n {:?}", res.inv_from_montgomery(), INV_MOD_A);
+        for i in 0..5 {
+            assert!(res[i] == INV_MOD_A[i]);
         }
     }
 }

--- a/src/field.rs
+++ b/src/field.rs
@@ -1,7 +1,5 @@
-use core::cmp::{Eq, PartialEq};
+use core::cmp::PartialEq;
 
-use subtle::ConditionallySelectable;
-use subtle::ConditionallyNegatable;
 use subtle::Choice;
 use subtle::ConstantTimeEq;
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -18,7 +18,6 @@ pub use backend::u64::field::*;
 #[cfg(feature = "u64_backend")]
 pub type FieldElement = backend::u64::field::FieldElement;
 
-impl Eq for FieldElement {}
 
 impl PartialEq for FieldElement {
     fn eq(&self, other: &FieldElement) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 // Used for traits related to constant-time code.
 extern crate subtle;
 extern crate curve25519_dalek;
-
+extern crate num;
 
 
 pub mod backend;


### PR DESCRIPTION
Implemented all of the necessary functions and tools to implement the `Kalinski Modular Inverse Algorithm` for `FieldElement`.

This consists on the following implementations:
- `PartialOrd`trait definition for `FieldElement`.
- `PartialEq` trait definition for `FieldElement`.
- `two_pow_k()` function implementation for `FieldElement` to enable perform: `2^k for 0<= k <=260`. Implemented on #10 
- `half()` function implementation for `FieldElement` to perform division by `2` for `FieldElement` just using bit shifting operators. Implemented on bad3691
- Implement `To/From` Montgomery domain conversions for `FieldElement` on #11 
- Implement `Kalinski's Modular Montgomery Inverse algorithm` on #9 

**Everything is tested, commented and documented**. 

> The idea is to Implement at some point Savas & Koç Montgomery Modular Inverse algorithm version and benchmark it vs #9 

Now we can continue with Point Addition algorithms that need the `inverse` operator to be performed. All ready to proceed with #8 