### PR TITLE
Implement `Neg` for EdwardsPoint.

### DIFF
--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -768,4 +768,31 @@ pub mod tests {
             assert!(out_mont_a[i] == A[i]);
         }
     }
+
+    #[test]
+    fn negation() {
+        let minus_a = -&A;
+        let minus_b = -&B;
+
+        for i in 0..5 {
+            assert!(minus_a[i] == MINUS_A[i]);
+            assert!(minus_b[i] == MINUS_B[i]);
+        }
+    }
+
+    #[test]
+    fn negate_one() {
+        let minus_one = -&FieldElement::one();
+        for i in 0..5 {
+            assert!(minus_one[i] == FieldElement::minus_one()[i]);
+        }
+    }
+
+    #[test]
+    fn negate_zero() {
+        let minus_zero = -&FieldElement::zero();
+        for i in 0..5 {
+            assert!(minus_zero[i] == FieldElement::zero()[i]);
+        }
+    }
 }

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -786,6 +786,11 @@ pub mod tests {
         for i in 0..5 {
             assert!(minus_one[i] == FieldElement::minus_one()[i]);
         }
+
+        let one = -&FieldElement::minus_one();
+        for i in 0..5 {
+            assert!(one[i] == FieldElement::one()[i]);
+        }
     }
 
     #[test]

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -6,9 +6,7 @@ use std::default::Default;
 use std::cmp::{PartialOrd, Ordering, Ord};
 
 use core::ops::{Index, IndexMut};
-use core::ops::Add;
-use core::ops::Sub;
-use core::ops::Mul;
+use core::ops::{Add, Sub, Mul, Neg};
 
 use num::Integer;
 
@@ -61,6 +59,16 @@ impl Ord for FieldElement {
         Ordering::Equal
     }
 }
+
+impl<'a> Neg for &'a FieldElement {
+    type Output = FieldElement;
+    /// Computes `-self (mod l)`.
+    /// Compute the negated value that correspond's to the
+    /// two's complement of the input FieldElement.
+    fn neg(self) -> FieldElement {
+        &FieldElement::zero() - self
+    }
+} 
 
 impl<'a, 'b> Add<&'b FieldElement> for &'a FieldElement {
     type Output = FieldElement;
@@ -519,17 +527,23 @@ pub mod tests {
     /// `A = 182687704666362864775460604089535377456991567872`
     pub static A: FieldElement = FieldElement([0, 0, 0, 2, 0]);
 
+    /// `-A (mod l) = 7237005577332262213973186562860306536190753494604447001912415560828462683117`.
+    pub static MINUS_A: FieldElement = FieldElement([671914833335277, 3916664325105025, 1367801, 4503599627370494, 17592186044415]);
+
     /// A on Montgomery domain = `(A * R (mod l)) = 474213518376757474787523690767343130291324218287585596341053150401850043342`.
     pub static INV_MONT_A: FieldElement = FieldElement([2317332620045262, 1576144597389635, 2025859686448975, 2756776639866422, 1152749206963]);
 
     /// `(A ^ (-1)) (mod l) = 7155219595916845557842258654134856828180378438239419449390401977965479867845`.
     pub static INV_MOD_A: FieldElement = FieldElement([1289905446467013, 1277206401232501, 2632844239031511, 61125669693438, 17393375336657]);
 
-    /// `(B ^ (-1)) (mod l) = 4972823702408169985605068068612629707457302171484944010058343536981337191056`.
-    pub static INV_MOD_B: FieldElement = FieldElement([3843051553829520, 3394345223148522, 3244765182786547, 3746084408926180, 12088264794607]);
-
     /// `B = 904625697166532776746648320197686575422163851717637391703244652875051672039`
     pub static B: FieldElement = FieldElement([2766226127823335, 4237835465749098, 4503599626623787, 4503599627370493, 2199023255551]);
+    
+    /// `-B (mod l) = 6332379880165729437226538242845307665434952507662270214298706285410402578950`.
+    pub static MINUS_B: FieldElement = FieldElement([2409288332882438, 4182428486726422, 2114509, 2, 15393162788864]);
+
+    /// `(B ^ (-1)) (mod l) = 4972823702408169985605068068612629707457302171484944010058343536981337191056`.
+    pub static INV_MOD_B: FieldElement = FieldElement([3843051553829520, 3394345223148522, 3244765182786547, 3746084408926180, 12088264794607]);
 
     /// `C = 2009874587549`
     pub static C: FieldElement = FieldElement([2009874587549, 0, 0, 0, 0]);

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -31,7 +31,34 @@ impl Debug for CompressedEdwardsY {
     }
 }
 
+impl Default for CompressedEdwardsY {
+    /// Returns the identity for `CompressedEdwardsY` point.
+    fn default() -> CompressedEdwardsY {
+        CompressedEdwardsY::identity()
+    }
+}
+
+impl Identity for CompressedEdwardsY {
+    /// Returns the `CompressedEdwards identity point value 
+    /// that corresponds to `1` (mod l)
+    /// with the sign bit setted to `0`.
+    fn identity() -> CompressedEdwardsY {
+        CompressedEdwardsY([1, 0, 0, 0, 0, 0, 0, 0,
+                            0, 0, 0, 0, 0, 0, 0, 0,
+                            0, 0, 0, 0, 0, 0, 0, 0,
+                            0, 0, 0, 0, 0, 0, 0, 0])
+    }
+}
+
 impl CompressedEdwardsY {
+    /// Construct a `CompressedEdwardsY` from a slice of bytes.
+    pub fn from_slice(bytes: &[u8]) -> CompressedEdwardsY {
+        let mut tmp = [0u8; 32];
+
+        tmp.copy_from_slice(bytes);
+
+        CompressedEdwardsY(tmp)
+    }
 
     /// Return the `CompressedEdwardsY` as an array of bytes (it's cannonical state).
     pub fn to_bytes(&self) -> [u8; 32] {
@@ -47,42 +74,18 @@ impl CompressedEdwardsY {
     }
 }
 
-impl Identity for CompressedEdwardsY {
-    fn identity() -> CompressedEdwardsY {
-        CompressedEdwardsY([1, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0])
-    }
-}
-
-impl Default for CompressedEdwardsY {
-    fn default() -> CompressedEdwardsY {
-        CompressedEdwardsY::identity()
-    }
-}
-
-impl CompressedEdwardsY {
-    /// Construct a `CompressedEdwardsY` from a slice of bytes.
-    pub fn from_slice(bytes: &[u8]) -> CompressedEdwardsY {
-        let mut tmp = [0u8; 32];
-
-        tmp.copy_from_slice(bytes);
-
-        CompressedEdwardsY(tmp)
-    }
-}
 
 
-/// An `EdwardsPoint` represents a point on the Edwards form of Doppio Curve.
-#[derive(Copy, Clone)]
+/// An `EdwardsPoint` represents a point on the Doppio Curve expressed
+/// over the Twisted Edwards Extended Coordinates.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct EdwardsPoint {
     pub(crate) X: FieldElement,
     pub(crate) Y: FieldElement,
     pub(crate) Z: FieldElement,
     pub(crate) T: FieldElement,
 }
-
+/*
 impl ConstantTimeEq for EdwardsPoint {
     fn ct_eq(&self, other: &EdwardsPoint) -> Choice {
         self.compress().ct_eq(&other.compress())
@@ -94,7 +97,7 @@ impl PartialEq for EdwardsPoint {
         self.ct_eq(other).unwrap_u8() == 1u8
     }
 }
-
+*/
 impl Default for EdwardsPoint {
     /// Returns the default EdwardsPoint Extended Coordinates: (0, 1, 1, 0). 
     fn default() -> EdwardsPoint {
@@ -218,5 +221,31 @@ pub mod tests {
     use super::*;
     use constants::*;
 
+    #[test]
+    fn edwards_extended_coords_neg() {
 
+        let inv_a: EdwardsPoint = EdwardsPoint{
+           X: FieldElement::minus_one(),
+           Y: FieldElement::zero(),
+           Z: FieldElement::zero(),
+           T: FieldElement::minus_one(),
+        };
+
+        let a: EdwardsPoint = EdwardsPoint{
+           X: FieldElement::one(),
+           Y: FieldElement::zero(),
+           Z: FieldElement::zero(),
+           T: FieldElement::one(),
+        };
+
+        let res = -a;
+        assert!(res == inv_a);
+    }
+
+    #[test]
+    fn edwards_extended_coords_neg_identity() {
+        let res = -EdwardsPoint::identity();
+
+        assert!(res == EdwardsPoint::identity())
+    }
 }

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -116,9 +116,16 @@ impl Identity for EdwardsPoint {
 
 impl<'a> Neg for &'a EdwardsPoint {
     type Output = EdwardsPoint;
-    /// Negates an `EdwardsPoint` giving it as a result
+    /// Negates an `EdwardsPoint` giving it as a result.
+    /// Since the negative of a point is (-X:Y:Z:-T), it
+    /// gives as a result: `(-X, Y, Z, -T)`.
     fn neg(self) -> EdwardsPoint {
-       unimplemented!()
+       EdwardsPoint{
+           X: -&self.X,
+           Y:   self.Y,
+           Z:   self.Z,
+           T: -&self.T,
+       }
     }
 }
 


### PR DESCRIPTION
To implement `EdwardsPoint` negation, we need to be able to
negate its coordinates (FieldElements indeed).

In order to do this, `Neg` trait has been implemented for
`FieldElement`.

Implemented the `Neg` trait for `EdwardsPoint,
which means the Negation operation of an
Twisted Edwards Extended Coordinates.

The negative of a point is (-X:Y:Z:-T).
