### PR TITLE
Implement `Neg`, `Index` & `IndexMut` for CompressedEdwardsY.

### DIFF
--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -800,4 +800,11 @@ pub mod tests {
             assert!(minus_zero[i] == FieldElement::zero()[i]);
         }
     }
+
+    #[test]
+    fn l_field_high_bit() {
+        let msb = &constants::FIELD_L.to_bytes();
+        let pos_sign = 1u8 << 7;
+        assert!(msb[31] < pos_sign);
+    }
 }

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -18,7 +18,7 @@ use std::ops::{Add, Sub, Mul, Neg};
 
 
 /// The first 255 bits of a `CompressedEdwardsY` represent the
-/// \\(y\\)-coordinate.  The high bit of the 32nd byte gives the sign of \\(x\\).
+/// (y)-coordinate.  The high bit of the 32nd byte gives the sign of (x).
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct CompressedEdwardsY(pub [u8; 32]);
 
@@ -51,6 +51,26 @@ impl Default for CompressedEdwardsY {
     /// Returns the identity for `CompressedEdwardsY` point.
     fn default() -> CompressedEdwardsY {
         CompressedEdwardsY::identity()
+    }
+}
+
+impl<'a> Neg for &'a CompressedEdwardsY {
+    type Output = CompressedEdwardsY;
+    /// Negates an `CompressedEdwardsY` by decompressing
+    /// it, negating over Twisted Edwards Extended 
+    /// Projective Coordinates and compressing it back.
+    fn neg(self) -> CompressedEdwardsY {
+        (-&self.decompress().unwrap()).compress()
+    }
+}
+
+impl Neg for CompressedEdwardsY {
+    type Output = CompressedEdwardsY;
+    /// Negates an `CompressedEdwardsY` by decompressing
+    /// it, negating over Twisted Edwards Extended 
+    /// Projective Coordinates and compressing it back.
+    fn neg(self) -> CompressedEdwardsY {
+        -& self
     }
 }
 

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -11,8 +11,11 @@ use subtle::Choice;
 use subtle::ConstantTimeEq;
 
 use std::default::Default;
-use std::ops::{Add, Sub, Mul, Neg};
 use std::fmt::Debug;
+
+use core::ops::{Index, IndexMut};
+use std::ops::{Add, Sub, Mul, Neg};
+
 
 /// The first 255 bits of a `CompressedEdwardsY` represent the
 /// \\(y\\)-coordinate.  The high bit of the 32nd byte gives the sign of \\(x\\).
@@ -22,6 +25,19 @@ pub struct CompressedEdwardsY(pub [u8; 32]);
 impl ConstantTimeEq for CompressedEdwardsY {
     fn ct_eq(&self, other: &CompressedEdwardsY) -> Choice {
         self.to_bytes().ct_eq(&other.to_bytes())
+    }
+}
+
+impl Index<usize> for CompressedEdwardsY {
+    type Output = u8;
+    fn index(&self, _index: usize) -> &u8 {
+        &(self.0[_index])
+    }
+}
+
+impl IndexMut<usize> for CompressedEdwardsY {
+    fn index_mut(&mut self, _index: usize) -> &mut u8 {
+        &mut (self.0[_index])
     }
 }
 


### PR DESCRIPTION
- Implemented the trait `Neg` for `&CompressedEdwardsY`
and `CompressedEdwardsY`.

- Implemented traits `Index` & `IndexMut` for
`CompressedEdwardsY` to be able to get
concrete parts of the slice that composes
the `CompressedEdwardsY` struct.

Also implemented tests to demonstrate that the encoding on bytes of a `FieldElement` will never disturb the compression of an `EdwardsPoint`.