### PR TITLE
Benchmark both modular inverse algorithms

### DIFF
--- a/benchmarks/dusk_benchmarks.rs
+++ b/benchmarks/dusk_benchmarks.rs
@@ -6,28 +6,45 @@ extern crate criterion;
 
 use criterion::{Criterion, Benchmark};
 
-use corretto::backend::u64::scalar::Scalar;
+use corretto::backend::u64::{scalar, field};
 
 
 
 mod scalar_benches {   
     use super::*; 
     // B = 904625697166532776746648320197686575422163851717637391703244652875051672039
-    pub static B: Scalar = Scalar([2766226127823335, 4237835465749098, 4503599626623787, 4503599627370493, 2199023255551]);
+    pub static B: scalar::Scalar = scalar::Scalar([2766226127823335, 4237835465749098, 4503599626623787, 4503599627370493, 2199023255551]);
 
     // BA = B - A = 904625697166532776746648320014998870755800986942176787613709275418060104167
-    pub static BA: Scalar = Scalar([2766226127823335, 4237835465749098, 4503599626623787, 4503599627370491, 2199023255551]);
+    pub static BA: scalar::Scalar = scalar::Scalar([2766226127823335, 4237835465749098, 4503599626623787, 4503599627370491, 2199023255551]);
     
     // Test if some implementation performs much better than the other even `inline`
     // forces to replace the code too. So both implementations should perform similarly.
     pub fn bench_mul_internal(c: &mut Criterion) {
     c.bench(
         "mul_internal",
-        Benchmark::new("Function", |b| b.iter(|| Scalar::mul_internal(&B, &BA)))
-            .with_function("Macro", |b| b.iter(|| Scalar::mul_internal_macros(&B, &BA))),
+        Benchmark::new("Function", |b| b.iter(|| scalar::Scalar::mul_internal(&B, &BA)))
+            .with_function("Macro", |b| b.iter(|| scalar::Scalar::mul_internal_macros(&B, &BA))),
     );
+    }
 }
 
+mod field_benches {
+
+    use super::*;
+
+    // /// `B = 904625697166532776746648320197686575422163851717637391703244652875051672039`
+    pub static B: field::FieldElement = field::FieldElement([2766226127823335, 4237835465749098, 4503599626623787, 4503599627370493, 2199023255551]);
+
+    pub fn bench_modular_inverse(c: &mut Criterion) {
+    c.bench(
+        "Modular Inverse",
+        Benchmark::new("Kalinski inverse", |b| b.iter(|| field::FieldElement::kalinski_inverse(&B))).
+            with_function("Savas & Koç inverse", |b| b.iter(|| field::FieldElement::savas_koc_inverse(&B))),
+    );
+    }
 }
-criterion_group!(benchmarks, scalar_benches::bench_mul_internal);
+
+criterion_group!(benchmarks, scalar_benches::bench_mul_internal, field_benches::bench_modular_inverse);
+//criterion_group!(benchmarks, field_benches::bench_modular_inverse);
 criterion_main!(benchmarks);

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -419,6 +419,7 @@ impl FieldElement {
     /// of the Montgomery Modular Inverse algorithm.
     /// B. S. Kaliski Jr. - The  Montgomery  inverse  and  its  applica-tions.
     /// IEEE Transactions on Computers, 44(8):1064–1065, August-1995
+    #[doc(hidden)]
     #[inline]
     pub fn kalinski_inverse(a: &FieldElement) -> FieldElement {
 

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -424,7 +424,7 @@ impl FieldElement {
         /// which tries to remove the expensive division operation away from the Classical
         /// Euclidean GDC algorithm replacing it for Bit-shifting, subtraction and comparaison.
         /// 
-        /// Output = `a^(-1) * 2^k (mod l)
+        /// Output = `a^(-1) * 2^k (mod l)` where `k = log2(FIELD_L) == 253`.
         /// 
         /// Stein, J.: Computational problems associated with Racah algebra.J. Comput. Phys.1, 397–405 (1967)
         /// 
@@ -523,6 +523,89 @@ impl FieldElement {
         // `r/2^260` carrying the `FieldElement` out of the 
         // Montgomery domain.
         r.from_montgomery()
+    }
+
+    /// Compute `a^-1 (mod l)` using the the Savas & Koç modular
+    /// inverse algorithm. It's an optimization of the Kalinski
+    /// modular inversion algorithm that extends the Binary GCD 
+    /// algorithm to perform the modular inverse operation.
+    /// 
+    /// The `PhaseII` it's substituded by 1 or 2 Montgomery Multiplications,
+    /// what makes the second part compute in almost ConstTime.
+    /// 
+    /// SPECIAL ISSUE ON MONTGOMERY ARITHMETIC. 
+    /// Montgomery inversion - Erkay Sava ̧s & Çetin Kaya Koç
+    /// J Cryptogr Eng (2018) 8:201–210
+    /// https://doi.org/10.1007/s13389-017-0161-x 
+    #[inline]
+    pub (crate) fn savas_koc_inverse(a: &FieldElement) -> FieldElement {
+
+        /// This Phase I indeed is the Binary GCD algorithm , a version o Stein's algorithm
+        /// which tries to remove the expensive division operation away from the Classical
+        /// Euclidean GDC algorithm replacing it for Bit-shifting, subtraction and comparaison.
+        /// 
+        /// Output = `a^(-1) * 2^k (mod l)` where `k = log2(FIELD_L) == 253`.
+        /// 
+        /// Stein, J.: Computational problems associated with Racah algebra.J. Comput. Phys.1, 397–405 (1967).
+        #[inline]
+        fn phase1(a: &FieldElement) -> (FieldElement, u64) {
+            // Declare L = 2^252 + 27742317777372353535851937790883648493
+            let p = FieldElement([671914833335277, 3916664325105025, 1367801, 0, 17592186044416]);
+            let mut u = p.clone();
+            let mut v = a.clone();
+            let mut r = FieldElement::zero();
+            let mut s = FieldElement::one();
+            let two = FieldElement([2, 0, 0, 0, 0]); 
+            let mut k = 0u64;
+
+            while v > FieldElement::zero() {
+                match(u.is_even(), v.is_even(), u > v, v >= u) {
+                    // u is even
+                    (true, _, _, _) => {
+
+                        u = u.half();
+                        s = &s * &two;
+                    },
+                    // u isn't even but v is even
+                    (false, true, _, _) => {
+
+                        v = v.half();
+                        r = &r * &two;
+                    },
+                    // u and v aren't even and u > v
+                    (false, false, true, _) => {
+
+                        u = &u - &v;
+                        u = u.half();
+                        r = &r + &s;
+                        s = &s * &two;
+                    },
+                    // u and v aren't even and v > u
+                    (false, false, false, true) => {
+
+                        v = &v - &u;
+                        v = v.half();
+                        s = &r + &s;
+                        r = &r * &two;
+                    },
+                    (false, false, false, false) => panic!("Unexpected error has ocurred."),
+                }
+                k += 1;
+            }
+            if r > p {
+                r = &r - &p;
+            }
+            (&p - &r, k)
+        }
+
+        let (mut r, mut z) = phase1(&a.clone());
+        if z > 260 {
+            r = FieldElement::montgomery_mul(&r, &FieldElement::one());
+            z = z - 260;
+        }
+        let fact = FieldElement::two_pow_k(&(260 - z));
+        r = FieldElement::montgomery_mul(&r, &fact);
+        r
     }
 }
     

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -925,4 +925,22 @@ pub mod tests {
             assert!(res[i] == INV_MOD_C[i]);
         }
     }
+    
+    #[test]
+    fn savas_koc_inverse() {
+        let res = FieldElement::savas_koc_inverse(&A);
+        for i in 0..5 {
+            assert!(res[i] == INV_MOD_A[i]);
+        }
+
+        let res = FieldElement::savas_koc_inverse(&B);
+        for i in 0..5 {
+            assert!(res[i] == INV_MOD_B[i]);
+        }
+
+        let res = FieldElement::savas_koc_inverse(&C);
+        for i in 0..5 {
+            assert!(res[i] == INV_MOD_C[i]);
+        }
+    }
 }

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -180,6 +180,7 @@ impl FieldElement {
     /// This function SHOULD ONLY be used with even 
     /// `FieldElements` otherways, can produce erroneus
     /// results.
+    #[inline]
     pub fn half(&self) -> FieldElement {
         let mut res = self.clone();
         let mut remainder = 0u64;
@@ -209,6 +210,7 @@ impl FieldElement {
     /// 
     /// On Kalinski's `PhaseII`, this function allows us to trick the
     /// addition and be able to divide odd numbers by `2`.
+    #[inline]
     pub fn plus_p_and_half(&self) -> FieldElement {
         let mut res = self.clone();
         for i in 0..5 {
@@ -418,7 +420,7 @@ impl FieldElement {
     /// B. S. Kaliski Jr. - The  Montgomery  inverse  and  its  applica-tions.
     /// IEEE Transactions on Computers, 44(8):1064–1065, August-1995
     #[inline]
-    pub (crate) fn kalinski_inverse(a: &FieldElement) -> FieldElement {
+    pub fn kalinski_inverse(a: &FieldElement) -> FieldElement {
 
         /// This Phase I indeed is the Binary GCD algorithm , a version o Stein's algorithm
         /// which tries to remove the expensive division operation away from the Classical
@@ -538,7 +540,7 @@ impl FieldElement {
     /// J Cryptogr Eng (2018) 8:201–210
     /// https://doi.org/10.1007/s13389-017-0161-x 
     #[inline]
-    pub (crate) fn savas_koc_inverse(a: &FieldElement) -> FieldElement {
+    pub fn savas_koc_inverse(a: &FieldElement) -> FieldElement {
 
         /// This Phase I indeed is the Binary GCD algorithm , a version o Stein's algorithm
         /// which tries to remove the expensive division operation away from the Classical


### PR DESCRIPTION
- Added a new module and implemented benchmarks to compare the computing time of the two different modular inverse implementations.

The results show the following:

```
Modular Inverse/Kalinski inverse
                        time:   [70.066 us 70.380 us 70.695 us]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low severe
  1 (1.00%) high mild
Modular Inverse/Savas & Koç inverse
                        time:   [61.951 us 62.161 us 62.382 us]
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
```

As we were expecting, Savas & Koç algorithm performs better than Kalinski's implementation. The order of the inverse operation stays on `us`  which is the same as in other high-speed libraries that use
most performant algorithms such as `addition chain techniques`.

- We will then stay with the Savas & Koç algorithm and hide the Kalinski one from the docs.

It's also important to point out that I compared our benchmark results from the `Savas & Koç modular inverse implementation` against the addition chain implementation of [Curve25519-dalek](https://github.com/dalek-cryptography/curve25519-dalek).

The results for the Scalar inversion of the 25519 were: 
```
Benchmarking Scalar inversion: Collecting 100 samples in estimated 5.0081 s (40                                                                               Scalar inversion        time:   [22.259 us 22.287 us 22.317 us]
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
```

So as we expected, an addition chain implementation is faster, but the order of the speed is `us` on both functions so we can accept it and research on addition chain implementations over the Doppio Curve later.

I guess we all agree on stay with Savas & Koç modular inverse algorithm right?

> NOTE: Benchmarks with -> Intel(R) Core(TM) i5-7300HQ CPU @ 2.50GHz
